### PR TITLE
mail-prepender.sh support Return-Path in the first line

### DIFF
--- a/bin/mail-prepender.sh
+++ b/bin/mail-prepender.sh
@@ -46,14 +46,18 @@ read -r line
 if [[ "$line" =~ ^(From|Return-Path:)\ .* ]]; then
   echo "$line"
   firstLine=""
+  if [[ "$line" =~ ^From\ .* ]]; then
+    read -r line
+    if [[ "$line" =~ ^Return-Path:\ .* ]]; then
+      echo "$line"
+      secondLine=""
+    else
+      secondLine="$line"
+    fi
+  fi
 else
   firstLine="$line"
-fi
-read -r line
-if [[ "$line" =~ ^Return-Path:\ .* ]]; then
-  echo "$line"
-  secondLine=""
-else
+  read -r line
   secondLine="$line"
 fi
 

--- a/bin/mail-prepender.sh
+++ b/bin/mail-prepender.sh
@@ -40,16 +40,15 @@ while getopts ":x:X:" opts; do
   esac
 done
 
-# A possible Mbox format's From line MUST come before any added headers
+# A possible Mbox format's From line MUST come before any added headers &
+# Return-Path header conventionally (spamassassin) comes before other headers
 read -r line
-if [[ "$line" =~ ^From\ .* ]]; then
+if [[ "$line" =~ ^(From|Return-Path:)\ .* ]]; then
   echo "$line"
   firstLine=""
 else
   firstLine="$line"
 fi
-
-# Return-Path header conventionally (spamassassin) comes before other headers
 read -r line
 if [[ "$line" =~ ^Return-Path:\ .* ]]; then
   echo "$line"


### PR DESCRIPTION
The `Return-Path` could be on the first line if there is no Mbox format's `From` line. If the first line had `Return-Path`, the second line is never special.